### PR TITLE
[cloudkitty] Add a default value for cloudkitty.s3StorageConfig

### DIFF
--- a/api/bases/telemetry.openstack.org_cloudkitties.yaml
+++ b/api/bases/telemetry.openstack.org_cloudkitties.yaml
@@ -576,6 +576,10 @@ spec:
                   Needed to request a transportURL that is created and used in CloudKitty
                 type: string
               s3StorageConfig:
+                default:
+                  secret:
+                    name: cloudkitty-loki-s3
+                    type: s3
                 description: S3 related configuration passed to Loki
                 properties:
                   schemas:

--- a/api/bases/telemetry.openstack.org_telemetries.yaml
+++ b/api/bases/telemetry.openstack.org_telemetries.yaml
@@ -1141,6 +1141,10 @@ spec:
                       Needed to request a transportURL that is created and used in CloudKitty
                     type: string
                   s3StorageConfig:
+                    default:
+                      secret:
+                        name: cloudkitty-loki-s3
+                        type: s3
                     description: S3 related configuration passed to Loki
                     properties:
                       schemas:

--- a/api/v1beta1/cloudkitty_types.go
+++ b/api/v1beta1/cloudkitty_types.go
@@ -109,6 +109,7 @@ type CloudKittySpecBase struct {
 
 	// S3 related configuration passed to Loki
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:default={secret: {name: "cloudkitty-loki-s3", type: "s3"}}
 	S3StorageConfig lokistackv1.ObjectStorageSpec `json:"s3StorageConfig"`
 
 	// Storage class used for Loki

--- a/config/crd/bases/telemetry.openstack.org_cloudkitties.yaml
+++ b/config/crd/bases/telemetry.openstack.org_cloudkitties.yaml
@@ -576,6 +576,10 @@ spec:
                   Needed to request a transportURL that is created and used in CloudKitty
                 type: string
               s3StorageConfig:
+                default:
+                  secret:
+                    name: cloudkitty-loki-s3
+                    type: s3
                 description: S3 related configuration passed to Loki
                 properties:
                   schemas:

--- a/config/crd/bases/telemetry.openstack.org_telemetries.yaml
+++ b/config/crd/bases/telemetry.openstack.org_telemetries.yaml
@@ -1141,6 +1141,10 @@ spec:
                       Needed to request a transportURL that is created and used in CloudKitty
                     type: string
                   s3StorageConfig:
+                    default:
+                      secret:
+                        name: cloudkitty-loki-s3
+                        type: s3
                     description: S3 related configuration passed to Loki
                     properties:
                       schemas:


### PR DESCRIPTION
The s3StorageConfig.secret is passed to Lokistack, which requires some value be set.
The default is needed, or else there will be an error when it is not configured.

The default is set to a reasonable value for the secret name (cloudkitty-loki-s3) and the type (s3), which match the values we're planning on using for the CI environment.
